### PR TITLE
fix: Remove fetchConnectionCache

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,7 +3,5 @@ import { drizzle } from "drizzle-orm/neon-http";
 import * as authSchema from "@/schema/auth-schema";
 import * as placesSchema from "@/schema/places-schema";
 
-neonConfig.fetchConnectionCache = true;
-
 const sql = neon(process.env.DATABASE_URL!);
 export const db = drizzle(sql, { schema: { ...authSchema, ...placesSchema } });


### PR DESCRIPTION
Remove `fetchConnectionCache` option to get rid of this annoying warning
<img width="968" height="40" alt="Capture 2025-11-15 at 14 00 42@2x" src="https://github.com/user-attachments/assets/c37bfb2d-f42b-4a26-9abc-034554beb61b" />
